### PR TITLE
[Fix] NPE in NfcA constructor.

### DIFF
--- a/core/java/android/nfc/tech/NfcA.java
+++ b/core/java/android/nfc/tech/NfcA.java
@@ -70,10 +70,10 @@ public final class NfcA extends BasicTagTechnology {
         super(tag, TagTechnology.NFC_A);
         Bundle extras;
         mSak = 0;
-        if(tag.hasTech(TagTechnology.MIFARE_CLASSIC))
-        {
+        if (tag.hasTech(TagTechnology.MIFARE_CLASSIC)) {
             extras = tag.getTechExtras(TagTechnology.MIFARE_CLASSIC);
-            mSak = extras.getShort(EXTRA_SAK);
+            if (extras != null)
+                mSak = extras.getShort(EXTRA_SAK);
         }
         extras = tag.getTechExtras(TagTechnology.NFC_A);
         mSak |= extras.getShort(EXTRA_SAK);


### PR DESCRIPTION
Bug detailed here:
https://stackoverflow.com/questions/64947925/mifareclassicget-throws-npe-on-android-10-but-not-on-android-8